### PR TITLE
Declared DOXYGEN_CONFIG_FILE to let the user decide the name and location of the doxygen config file

### DIFF
--- a/DoxygenRule.cmake
+++ b/DoxygenRule.cmake
@@ -5,7 +5,11 @@ if(NOT DOXYGEN_FOUND)
   return()
 endif()
 
-configure_file(doc/Doxyfile ${CMAKE_BINARY_DIR}/doc/Doxyfile @ONLY)
+if(NOT DOXYGEN_CONFIG_FILE)
+  # Assuming there exists a Doxyfile and that needs configuring
+  configure_file(doc/Doxyfile ${CMAKE_BINARY_DIR}/doc/Doxyfile @ONLY)
+  set(DOXYGEN_CONFIG_FILE ${CMAKE_BINARY_DIR}/doc/Doxyfile)
+endif()
 
 get_property(INSTALL_DEPENDS GLOBAL PROPERTY ALL_DEP_TARGETS)
 add_custom_target(doxygen_install
@@ -13,7 +17,7 @@ add_custom_target(doxygen_install
   DEPENDS ${ALL_DEP_TARGETS})
 
 add_custom_target(doxygen
-  ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/doc/Doxyfile
+  ${DOXYGEN_EXECUTABLE} ${DOXYGEN_CONFIG_FILE}
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/doc
   COMMENT "Generating API documentation using doxygen" VERBATIM)
 add_dependencies(doxygen doxygen_install)


### PR DESCRIPTION
Otherwise DoxygenRule must be included from the top level CMakeLists.txt and the file must be doc/Doxyfile.

Also, DoxygenRule,cmake needs documentation to include this
