### PR TITLE
Set working directory for all cpp unit tests to the /tests directory.

### DIFF
--- a/CommonCTest.cmake
+++ b/CommonCTest.cmake
@@ -2,7 +2,7 @@
 #               2010-2014, Stefan Eilemann <eile@eyescale.ch>
 
 if(NOT WIN32) # tests want to be with DLLs on Windows - no rpath
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
 include_directories(${CMAKE_CURRENT_LIST_DIR}/cpp ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
All unit test executables go into /tests, but their working directory was CMAKE_CURRENT_BINARY_DIR (default for add_test). This meant that when doing "include(CommonCTest)" from a subfolder (tests/cpp/CMakeLists.txt) they had as working directory tests/cpp/ and couldn't access test resources installed in /tests. It is of course possible to work around this by installing the ressources into tests/cpp, but I think it is more intuitive that the working directory corresponds to the executable location.
