### PR TITLE
Fix Git warning

### DIFF
--- a/Doxygit.cmake
+++ b/Doxygit.cmake
@@ -170,7 +170,7 @@ file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/index.html" "${DOXYGIT_TOC_POST}
 configure_file("${CMAKE_CURRENT_BINARY_DIR}/index.html"
   "${CMAKE_SOURCE_DIR}/index.html" COPYONLY)
 
-execute_process(COMMAND "${GIT_EXECUTABLE}" add images ${Entries}
+execute_process(COMMAND "${GIT_EXECUTABLE}" add --all images ${Entries}
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
 # hack to detect that not invoked as script and not under CI


### PR DESCRIPTION
warning: You ran 'git add' with neither '-A (--all)' or '--ignore-removal', 
whose behaviour will change in Git 2.0 with respect to paths you removed. 
Paths like 'Collage-1.1/CoverageReport/CMake/common/cpp/index-sort-f.html'
that are removed from your working tree are ignored with this version of Git.
