### PR TITLE
Adding different command for the tests

### DIFF
--- a/CommonCPPCTest.cmake
+++ b/CommonCPPCTest.cmake
@@ -47,7 +47,11 @@ foreach(FILE ${TEST_FILES})
   get_target_property(EXECUTABLE ${NAME} LOCATION)
   string(REGEX REPLACE "\\$\\(.*\\)" "\${CTEST_CONFIGURATION_TYPE}"
          EXECUTABLE "${EXECUTABLE}")
-  add_test(${NAME} ${EXECUTABLE})
+  if(${NAME}_TEST_COMMAND)
+     add_test(${NAME} ${EXECUTABLE} COMMAND ${${NAME}_TEST_COMMAND})
+  else()
+     add_test(${NAME} ${EXECUTABLE})
+  endif()
 endforeach()
 
 add_custom_target(run_cpp_tests


### PR DESCRIPTION
Users want to execute their own commands for the tests.

Therefore if they define in CMakeLists.txt:
set(client_configUpdate_TEST_COMMAND "mpirun -n 4 client_configUpdate" ) // The command to run for client_configUpdate test

then they can apply different commands.
