### PR TITLE
Allow CommonCPPCTest in multiple directories

### DIFF
--- a/CommonCPPCTest.cmake
+++ b/CommonCPPCTest.cmake
@@ -64,10 +64,14 @@ foreach(FILE ${TEST_FILES})
   endif()
 endforeach()
 
-add_custom_target(run_cpp_tests
-  COMMAND ${CMAKE_CTEST_COMMAND} \${ARGS} DEPENDS ${ALL_CPP_TESTS}
-  WORKING_DIRECTORY ${${CMAKE_PROJECT_NAME}_BINARY_DIR}
-  COMMENT "Running all cpp unit tests")
-if(COVERAGE)
-  add_dependencies(run_cpp_tests lcov-clean)
+if(TARGET run_cpp_tests)
+  add_dependencies(run_cpp_tests ${ALL_CPP_TESTS})
+else()
+  add_custom_target(run_cpp_tests
+    COMMAND ${CMAKE_CTEST_COMMAND} \${ARGS} DEPENDS ${ALL_CPP_TESTS}
+    WORKING_DIRECTORY ${${CMAKE_PROJECT_NAME}_BINARY_DIR}
+    COMMENT "Running all cpp unit tests")
+  if(COVERAGE)
+    add_dependencies(run_cpp_tests lcov-clean)
+  endif()
 endif()


### PR DESCRIPTION
Now that the tests are being created subject to some more customization with variables, it is useful to delegate test creation in subdirectories to their own CMakeLists.txt files, with their own specific settings.

This patch adds the test executables as dependencies of run_cpp_tests if it already exists, allowing CommonCPPCTest to be included in multiple CMakeLists.txt files.
