### PR TITLE
Fix Documentation Package URL for non-eyescale projects.

### DIFF
--- a/Common.cmake
+++ b/Common.cmake
@@ -82,14 +82,6 @@ if(NOT DOC_DIR)
   set(DOC_DIR share/${CMAKE_PROJECT_NAME}/doc)
 endif()
 
-if(NOT DPUT_HOST)
-  if(RELEASE_VERSION)
-    set(DPUT_HOST "ppa:eilemann/equalizer")
-  else()
-    set(DPUT_HOST "ppa:eilemann/equalizer-dev")
-  endif()
-endif()
-
 include(${CMAKE_CURRENT_LIST_DIR}/CMakeInstallPath.cmake)
 
 # Boost settings

--- a/Doxygit.cmake
+++ b/Doxygit.cmake
@@ -16,6 +16,9 @@
 # Optional Input Variables:
 # * DOXYGIT_MAX_VERSIONS number of versions to keep in directory (default: 10)
 # * DOXYGIT_TOC_POST html content to insert in 'index.html' (default: '')
+#
+# Input files:
+# ${CMAKE_CURRENT_SOURCE_DIR}/${Entry}/ProjectInfo.cmake additional project info
 
 # CMake escapes the whitespaces when passing a string to a script
 if(DOXYGIT_TOC_POST)


### PR DESCRIPTION
DPUT_HOST must not be set by default for all projects or all projects get a link to eilemann/equalizer in the documentation index page.
