### PR TITLE
Custom file paths exclusion for cppcheck

### DIFF
--- a/CppcheckTargets.cmake
+++ b/CppcheckTargets.cmake
@@ -187,6 +187,12 @@ function(add_cppcheck _name)
       return()
     endif()
 
+    if (CPPCHECK_IGNORED_PATHS)
+      string(REPLACE " " " -i" _ignored_paths ${CPPCHECK_IGNORED_PATHS})
+      set(CPPCHECK_IGNORED_PATHS ${_ignored_paths})
+      MESSAGE ("This is message: ${CPPCHECK_IGNORED_PATHS}")
+    endif(CPPCHECK_IGNORED_PATHS)
+
     if("1.${CMAKE_VERSION}" VERSION_LESS "1.2.8.0")
       # Older than CMake 2.8.0
       add_test(${_name}_cppcheck_test

--- a/Findcppcheck.cmake
+++ b/Findcppcheck.cmake
@@ -15,6 +15,7 @@
 #  CPPCHECK_WARN_REGULAR_EXPRESSION
 #  CPPCHECK_MARK_AS_ADVANCED - whether to mark our vars as advanced even
 #    if we don't find this program.
+#  CPPCHECK_IGNORED_PATHS
 #
 # Requires these CMake modules:
 #  FindPackageHandleStandardArgs (known included with CMake >=2.6.2)

--- a/TargetHooks.cmake
+++ b/TargetHooks.cmake
@@ -7,7 +7,7 @@ include(CpplintTargets)
 
 set(ALL_DEP_TARGETS "")
 set(ALL_LIB_TARGETS "")
-set(CPPCHECK_EXTRA_ARGS --suppress=unusedFunction --suppress=missingInclude
+set(CPPCHECK_EXTRA_ARGS --suppress=unusedFunction --suppress=missingInclude ${CPPCHECK_IGNORED_PATHS}
   -I${OUTPUT_INCLUDE_DIR} -D${UPPER_PROJECT_NAME}_STATIC=)
 
 macro(add_executable _target)


### PR DESCRIPTION
This commit defines and manage a CMakeList variable that enables a custom exclusion of source files when running ccpcheck by means of "make cppcheck" or "make test".

It has been successfully tested with the HBP project named neurorobotics/ESVRender for which we wanted to exclude large source files imported from external software (namely some flawed  OpenSceneGraph's shadowmap files) that had undergone very small modifications.
