### PR TITLE
Add option to override CMake's ConfigVersion.cmake.in template.

### DIFF
--- a/PackageConfig.cmake
+++ b/PackageConfig.cmake
@@ -16,7 +16,7 @@
 #     to remove from the list of exported libraries
 #   ${UPPER_PROJECT_NAME}_CONFIG_VERSION_IN - If set, use this template in
 #     preference to CMake's BasicConfigVersion-SameMajorVersion.cmake.in.
-#     The PACKAGE_VERSION variable is set before perforiming the instantiation.
+#     The PACKAGE_VERSION variable is set before performing the instantiation.
 #
 # Output variables
 #   ${UPPER_PROJECT_NAME}_FOUND - Was the project and all of the specified

--- a/PackageConfig.cmake
+++ b/PackageConfig.cmake
@@ -16,7 +16,7 @@
 #     to remove from the list of exported libraries
 #   ${UPPER_PROJECT_NAME}_CONFIG_VERSION_IN - If set, use this template in
 #     preference to CMake's BasicConfigVersion-SameMajorVersion.cmake.in.
-#     The PACKAGE_VERSION variable is set before performing the instantiation.
+#     The CVF_PACKAGE_VERSION variable is set before performing the instantiation.
 #
 # Output variables
 #   ${UPPER_PROJECT_NAME}_FOUND - Was the project and all of the specified
@@ -388,7 +388,7 @@ configure_file(
 
 # create and install ProjectConfigVersion.cmake
 if(${UPPER_PROJECT_NAME}_CONFIG_VERSION_IN)
-  set(PACKAGE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}")
+  set(CVF_PACKAGE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}")
   configure_file("${${UPPER_PROJECT_NAME}_CONFIG_VERSION_IN}" "${PROJECT_BINARY_DIR}/pkg/${PROJECT_NAME}ConfigVersion.cmake" @ONLY)
 else()
   write_basic_package_version_file(

--- a/PackageConfig.cmake
+++ b/PackageConfig.cmake
@@ -14,6 +14,9 @@
 #     are produced
 #   ${UPPER_PROJECT_NAME}_EXCLUDE_LIBRARIES - A list of library targets
 #     to remove from the list of exported libraries
+#   ${UPPER_PROJECT_NAME}_CONFIG_VERSION_IN - If set, use this template in
+#     preference to CMake's BasicConfigVersion-SameMajorVersion.cmake.in.
+#     The PACKAGE_VERSION variable is set before perforiming the instantiation.
 #
 # Output variables
 #   ${UPPER_PROJECT_NAME}_FOUND - Was the project and all of the specified
@@ -384,9 +387,14 @@ configure_file(
 )
 
 # create and install ProjectConfigVersion.cmake
-write_basic_package_version_file(
-  ${PROJECT_BINARY_DIR}/pkg/${PROJECT_NAME}ConfigVersion.cmake
-  VERSION ${VERSION_MAJOR}.${VERSION_MINOR} COMPATIBILITY SameMajorVersion)
+if(${UPPER_PROJECT_NAME}_CONFIG_VERSION_IN)
+  set(PACKAGE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}")
+  configure_file("${${UPPER_PROJECT_NAME}_CONFIG_VERSION_IN}" "${PROJECT_BINARY_DIR}/pkg/${PROJECT_NAME}ConfigVersion.cmake" @ONLY)
+else()
+  write_basic_package_version_file(
+    ${PROJECT_BINARY_DIR}/pkg/${PROJECT_NAME}ConfigVersion.cmake
+    VERSION ${VERSION_MAJOR}.${VERSION_MINOR} COMPATIBILITY SameMajorVersion)
+endif()
 
 install(
   FILES ${PROJECT_BINARY_DIR}/pkg/${PROJECT_NAME}Config.cmake


### PR DESCRIPTION
CMake's write_basic_package_version_file() function uses a set of
files BasicConfigVersion-....cmake.in to configure the package
ConfigVersion.cmake file. These templates contain code that
compare the pointer word size between the calling find_package()
environment and that used when the package was built, in a
misguided attempt to enforce ABI compatibility.

For packages that just supply executables, this test is
simply counter-productive, particularly in a cross-compilation
environment.

This patch allows one to use one's own ConfigVersion template
file.