### PR TITLE
Allow absolute paths for test scripts.

### DIFF
--- a/TestScriptUtils.cmake
+++ b/TestScriptUtils.cmake
@@ -57,8 +57,13 @@ function(add_test_script NAME SCRIPT INTERP)
         set(RUN_ARGS ${${NAME}_TEST_ARGS})
     endif()
 
+    set(SCRIPT_PATH "${SCRIPT}")
+    if(NOT IS_ABSOLUTE "${SCRIPT_PATH}")
+	set(SCRIPT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/${SCRIPT_PATH}")
+    endif()
+
     add_test(NAME ${NAME}
-        COMMAND ${RUN_PREFIX} ${INTERP} "${CMAKE_CURRENT_SOURCE_DIR}/${SCRIPT}" ${RUN_ARGS}
+        COMMAND ${RUN_PREFIX} ${INTERP} "${SCRIPT_PATH}" ${RUN_ARGS}
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}") 
 
     # Add test labels


### PR DESCRIPTION
Sometimes a test script is generated at build time using, for example, configure_file(). In this instance the path to the script should be based on CMAKE_CURRENT_BINARY_DIR or similar, and will be an absolute path.

This change forces add_test_script() not to prepend the current source directory if the test script path is absolute.