### PR TITLE
Make addition of github user remote opt-in.

### DIFF
--- a/GitExternal.cmake
+++ b/GitExternal.cmake
@@ -35,13 +35,6 @@ endif()
 include(CMakeParseArguments)
 
 set(GIT_EXTERNAL_USER $ENV{GIT_EXTERNAL_USER})
-if(NOT GIT_EXTERNAL_USER)
-  if(MSVC)
-    set(GIT_EXTERNAL_USER $ENV{USERNAME})
-  else()
-    set(GIT_EXTERNAL_USER $ENV{USER})
-  endif()
-endif()
 set(GIT_EXTERNAL_USER_FORK ${GIT_EXTERNAL_USER} CACHE STRING
   "Github user name used to setup remote for user forks")
 


### PR DESCRIPTION
Only add a 'user' remote to a github repository
if the GIT_EXTERNAL_USER environment variable is
explicitly set.

This is a temporary work-around for an issue
where projects using Eyescake/CMake are triggering
user prompts for github credentials — essentially
the user remote functionality fails noisily.