### PR TITLE
Export version major + minor for correct version sort in Jekyll.

### DIFF
--- a/DoxygenRule.cmake
+++ b/DoxygenRule.cmake
@@ -120,6 +120,8 @@ file(WRITE ${_jekyll_md_file}
 "---\n"
 "name: ${PROJECT_NAME}\n"
 "version: ${VERSION_MAJOR}.${VERSION_MINOR}\n"
+"major: ${VERSION_MAJOR}\n"
+"minor: ${VERSION_MINOR}\n"
 "description: ${${UPPER_PROJECT_NAME}_DESCRIPTION}\n"
 "issuesurl: ${${UPPER_PROJECT_NAME}_ISSUES_URL}\n"
 "packageurl: ${${UPPER_PROJECT_NAME}_PACKAGE_URL}\n"


### PR DESCRIPTION
These two fields are need because github pages uses --safe mode which does not allow plugins, so there is no way to do a proper version sort on the version string.
eyescale and bluebrain have already been updated to use this mechanism.