### PR TITLE
target warnings in ninja, explicit config superprojects

### DIFF
--- a/DoxygenRule.cmake
+++ b/DoxygenRule.cmake
@@ -142,11 +142,13 @@ if(GIT_DOCUMENTATION_REPO)
       DEPENDS ${PROJECT_NAME}_doxygen VERBATIM)
   else()
     add_custom_target(${PROJECT_NAME}_doxycopy
-      COMMENT "doxycopy target not available, missing ${_GIT_DOC_SRC_DIR}")
+      COMMAND ${CMAKE_COMMAND} -E echo
+      "doxycopy target not available, missing ${_GIT_DOC_SRC_DIR}")
   endif()
 else()
   add_custom_target(${PROJECT_NAME}_doxycopy
-    COMMENT "doxycopy target not available, missing GIT_DOCUMENTATION_REPO")
+    COMMAND ${CMAKE_COMMAND} -E echo
+    "doxycopy target not available, missing GIT_DOCUMENTATION_REPO for ${PROJECT_NAME}")
 endif()
 
 if(NOT TARGET doxycopy)

--- a/Doxygit.cmake
+++ b/Doxygit.cmake
@@ -210,4 +210,5 @@ endif()
 
 execute_process(
   COMMAND "${GIT_EXECUTABLE}" add --all images ${Entries} ${RemovedEntries}
-  css/github.css index.html WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+  css/github.css index.html _projects/*.md
+  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
Re 931bf29: The always-automatic include of *cmake is dangerous for projects which do have cmake files in the top-level directory (hello @biddisco). config superprojects have to explicitly call subproject_configure (see https://bbpcode.epfl.ch/code/#/c/11763/).