### PR TITLE
Restore missing cppcheck include for version.h (remove in #284)

### DIFF
--- a/TargetHooks.cmake
+++ b/TargetHooks.cmake
@@ -11,8 +11,10 @@ include(CpplintTargets)
 
 set(ALL_DEP_TARGETS "")
 set(ALL_LIB_TARGETS "")
+
+# ${PROJECT_NAMESPACE}_API= -> Fix cppcheck error about not including version.h
 set(CPPCHECK_EXTRA_ARGS
-  -D${UPPER_PROJECT_NAME}_STATIC= -D${UPPER_PROJECT_NAME}_API=)
+  -D${UPPER_PROJECT_NAME}_STATIC= -D${PROJECT_NAMESPACE}_API=)
 
 # only ever define this macro once, in case subprojects include the same rules
 get_property(ADD_EXE_DEFINED GLOBAL PROPERTY ADD_EXE_MACRO_DEFINED)


### PR DESCRIPTION
@tribal-tec FYI - This folder was removed from includes in #284 . This breaks the compilation of BBPSDK after the update:

https://bbpcode.epfl.ch/ci/job/common.BBPSDK.gerrit/build_type=Debug,platform=cscsviz/261/testReport/projectroot.gpfs.bbpcscsch.home.bbprelman.jenkins-cscs-02.workspace.commonBBPSDKgerrit.build_type.Debug.platform.cscsviz/BBP/cppcheck_test_BBPSDK/
