### PR TITLE
Clean COMMON_QT_SUPPORT_SOURCES variable.

### DIFF
--- a/CommonQtSupport.cmake
+++ b/CommonQtSupport.cmake
@@ -11,6 +11,7 @@
 # * COMMON_QT_SUPPORT_SOURCES
 
 macro(COMMON_QT_SUPPORT NAME)
+  set(COMMON_QT_SUPPORT_SOURCES "")
   if(${NAME}_MOC_HEADERS)
     if(NOT Qt5Core_FOUND)
       message(FATAL_ERROR "Qt5Core not found, needed for MOC of application ${Name}")


### PR DESCRIPTION
If this variable is not cleared its content accumulates from one common_application call to another. In our case that lead to multiple defined references linking errors.