### PR TITLE
DoxygenRule - fix Jekyll indexing for minor versions which end with 0

### DIFF
--- a/DoxygenRule.cmake
+++ b/DoxygenRule.cmake
@@ -138,7 +138,7 @@ set(_jekyll_md_file "${PROJECT_BINARY_DIR}/doc/${PROJECT_NAME}-${VERSION_MAJOR}.
 file(WRITE ${_jekyll_md_file}
 "---\n"
 "name: ${PROJECT_NAME}\n"
-"version: ${VERSION_MAJOR}.${VERSION_MINOR}\n"
+"version: "${VERSION_MAJOR}.${VERSION_MINOR}"\n"
 "major: ${VERSION_MAJOR}\n"
 "minor: ${VERSION_MINOR}\n"
 "description: ${${UPPER_PROJECT_NAME}_DESCRIPTION}\n"


### PR DESCRIPTION
e.g. Lunchbox v. 1.10 was parsed as a float and displayed as 1.1, also breaking the link. Sorting was not affected because it is based on the major + minor entries. Already fixed here: http://eyescale.github.io/