### PR TITLE
Fix SubProject find_package to work with /cmake/lib/project paths

### DIFF
--- a/SubProject.cmake
+++ b/SubProject.cmake
@@ -126,7 +126,11 @@ function(add_subproject name)
     add_subdirectory("${__common_source_dir}/${path}"
                      "${CMAKE_BINARY_DIR}/${name}")
     if(NOT ${name}_SKIP_FIND)
-      find_package(${name} REQUIRED QUIET) # find subproject "package"
+      # find subproject "package"       
+      find_package(${name} REQUIRED QUIET
+        HINTS "${CMAKE_BINARY_DIR}/${name}"
+              "${CMAKE_BINARY_DIR}/${name}/lib/cmake/${name}"
+      )
       include_directories(${${NAME}_INCLUDE_DIRS})
     endif()
     set(${name}_IS_SUBPROJECT ON PARENT_SCOPE)


### PR DESCRIPTION
Some projects put their ${project}Config.cmake files in locations
other than the root. The recent changes to SubProjects added an
automatic find and do not look in those locations.