### PR TITLE
Fix find_package using <prefix>/cmake/lib/<project> config path

### DIFF
--- a/SubProject.cmake
+++ b/SubProject.cmake
@@ -123,6 +123,9 @@ function(add_subproject name)
     if(NOT ${name}_DIR)
       set(${name}_DIR "${CMAKE_BINARY_DIR}/${name}" CACHE PATH
         "Location of ${name} project" FORCE)
+      # update CMAKE_PREFIX_PATH with path of package in this scope and parent scope
+      set(CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/${name}" ${CMAKE_PREFIX_PATH})
+      set(CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/${name}" ${CMAKE_PREFIX_PATH} PARENT_SCOPE)
     endif()
 
     subproject_install_packages(


### PR DESCRIPTION
```
In the cmake documentation
http://www.cmake.org/cmake/help/v3.2/manual/cmake-packages.7.html
it states that "One place it looks is: <prefix>/lib/cmake/Foo*/ where
Foo* is a case-insensitive globbing expression?

This solves the problem of projects that generate <project>Config.cmake in
the root, or in the lib/cmake/<project> location at build time.
```
