### PR TITLE
Warn users of TestCPP11 if it runs multiple times (for each subproject)

### DIFF
--- a/TestCPP11.cmake
+++ b/TestCPP11.cmake
@@ -7,6 +7,11 @@ if(TESTS_CPP11_DONE)
 endif()
 set(TESTS_CPP11_DONE ON)
 
+if(NOT PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+  message(WARNING "For better performance, include TestCPP11 in the top-level "
+    "project so that it is run only once.")
+endif()
+
 set(TESTS_CPP11 sharedptr tuple auto nullptr array final_override unordered_map
   template_alias)
 


### PR DESCRIPTION
It increases verbosity by one line, but it allows to spot inefficient multiple inclusions. In DisplayCluster for instance, Subproject was included before Common (right after GitExternals), and as a result TESTS_CPP11 was run for every subproject, then again for the superproject