### PR TITLE
Fix bug introduced by #395

### DIFF
--- a/CppcheckTargets.cmake
+++ b/CppcheckTargets.cmake
@@ -91,6 +91,9 @@ function(add_cppcheck _name)
   endif()
 
   cmake_parse_arguments(add_cppcheck "" "EXCLUDE_PATTERN" "" ${ARGN})
+  if(NOT add_cppcheck_EXCLUDE_PATTERN)
+    set(add_cppcheck_EXCLUDE_PATTERN "^$") # Empty string regex
+  endif()
 
   get_target_property(_cppcheck_sources "${_name}" SOURCES)
   set(_files)

--- a/CpplintTargets.cmake
+++ b/CpplintTargets.cmake
@@ -83,6 +83,11 @@ function(add_cpplint _name)
     list(APPEND _cpplint_args "--linelength=${add_cpplint_LINELENGTH}")
   endif()
 
+  # handles exclude pattern
+  if(NOT add_cpplint_EXCLUDE_PATTERN)
+    set(add_cpplint_EXCLUDE_PATTERN "^$") # Empty string regex
+  endif()
+
   get_target_property(_imported_target "${_name}" IMPORTED)
   if(_imported_target)
     return()

--- a/clangcheckTargets.cmake
+++ b/clangcheckTargets.cmake
@@ -46,6 +46,9 @@ function(add_clangcheck _name)
   endif()
 
   cmake_parse_arguments(add_clangcheck "" "EXCLUDE_PATTERN" "" ${ARGN})
+  if(NOT add_clangcheck_EXCLUDE_PATTERN)
+    set(add_clangcheck_EXCLUDE_PATTERN "^$") # Empty string regex
+  endif()
 
   get_target_property(_clangcheck_sources "${_name}" SOURCES)
   set(_files)


### PR DESCRIPTION
If one of the common_check_targets functions was called without the EXCLUDE_PATTERN parameter, an invalid CMake string MATCH expression would occur.