### PR TITLE
Make missing required dependencies not FATAL_ERROR

### DIFF
--- a/SubProject.cmake
+++ b/SubProject.cmake
@@ -153,11 +153,6 @@ function(add_subproject name)
 
   add_subdirectory("${__common_source_dir}/${path}"
     "${CMAKE_BINARY_DIR}/${name}")
-  if(NOT ${name}_SKIP_FIND)
-    # find subproject "package"
-    find_package(${name} REQUIRED QUIET)
-    include_directories(${${NAME}_INCLUDE_DIRS})
-  endif()
   set(${name}_IS_SUBPROJECT ON PARENT_SCOPE)
   # Mark globally that we've already used name as a sub project
   set_property(GLOBAL PROPERTY ${name}_IS_SUBPROJECT ON)
@@ -176,10 +171,7 @@ macro(git_subproject name url tag)
     string(TOUPPER ${name} NAME)
     if(NOT ${NAME}_FOUND AND NOT ${name}_FOUND)
       get_property(__included GLOBAL PROPERTY ${name}_IS_SUBPROJECT)
-      if(__included) # already used as a sub project, just find it:
-        find_package(${name} QUIET REQUIRED CONFIG
-          HINTS ${CMAKE_BINARY_DIR}/${NAME})
-      else()
+      if(NOT __included)
         if(NOT EXISTS ${__common_source_dir}/${name})
           # Always try first using Config mode, then Module mode.
           find_package(${name} QUIET CONFIG)


### PR DESCRIPTION
Takes the basic idea from BRayns, luckily common_package is a macro to allow the retur() out of the top-level CMakeLists. Sample configure run provided below. Also removed the superfluous/harmful extra find_package in SubProject.cmake @biddisco complained about.


```
-- Configured Hello [ff94cfa] with Boost
-- Configured Servus [4e4ea43] with DNSSD Boost Threads
-- Configured Deflect [83aaa6b] with Boost GLUT LibJpegTurbo OpenGL Qt5Concurrent Qt5Core Qt5Network Qt5Qml Qt5Quick Qt5Widgets Servus
-- Configured ZeroBuf [23ac6b4] with Boost Servus
-- Configured Lunchbox [33a354c] with Boost leveldb Servus WITHOUT hwloc MPI OpenMP skv
-- Not configured osgTransparency: Required OpenSceneGraph not found
-- Configured Pression [e813e22] with LibJpegTurbo Lunchbox WITHOUT OpenMP
-- Configured vmmlib [66a1b6d] with Boost
-- Configured Brion [d76760e] with BBPTestData Boost HDF5 Lunchbox vmmlib WITHOUT OpenMP
-- Configured Collage [fa984ee] with Boost Lunchbox Pression WITHOUT OFED UDT
-- Configured dash [6e05142] with Boost Lunchbox
-- Configured TUIO [b002886] with GLUT OpenGL SDL
-- Not configured DisplayCluster: Required MPI not found
-- Configured GLStats [3c76246] with Lunchbox OpenGL
-- Configured hwsd [bb9fea4] with Boost Lunchbox OpenGL Qt5Core Qt5Network Servus X11
-- Configured zeq [6229239] with Boost FlatBuffers libzmq Servus Threads ZeroBuf
-- Configured BBPSDK [b248d40] with BBPTestData Boost Brion Java JNI Lunchbox PythonInterp PythonLibs vmmlib WITHOUT BBPDocumentation OpenMP SWIG
-- Configured Equalizer [7bfcd4a] with Boost Collage Deflect GLStats hwsd Lunchbox MAGELLAN OpenGL Pression Qt5Core Qt5Gui Qt5Widgets vmmlib VRPN GLEW_MX WITHOUT hwloc OpenCV OpenSceneGraph X11 hwloc
-- GLX window system not supported: Skipping example eqCPU
-- Linking boost testing libs dynamically...
-- Boost version: 1.59.0
-- Found the following Boost libraries:
--   unit_test_framework
--   system
--   regex
--   date_time
--   thread
--   filesystem
--   program_options
--   chrono
--   atomic
-- Configured RESTBridge [a126090] with Boost cppnetlib FlatBuffers zeq
-- Configured Monsteer [96c8f40] with BBPTestData Boost Brion FlatBuffers Lunchbox PythonInterp PythonLibs vmmlib zeq WITHOUT MPI music
-- Configured NeuMesh [b6d1f48] with BBPSDK BBPTestData Boost Brion GTK2 GTS HDF5 Lunchbox OpenGL PythonInterp vmmlib VTK WITHOUT OpenMP
-- Not configured BRayns: Required OSPRay not found
-- Configured Livre [af4e4b8] with BBPTestData Boost Collage dash Equalizer FlatBuffers GLEW_MX LibJpegTurbo Lunchbox Monsteer OpenGL PNG Qt5Core Qt5OpenGL Qt5Widgets RESTBridge Threads zeq WITHOUT OpenMP Tuvok VTune
-- Not configured RTNeuron: Required OpenSceneGraph not found
-- Configured Cubist [0875a40] with Boost GLEW_MX Livre OpenGL VTK
-- Performing Test C_HAS_WARNING-Wformat=2
-- Performing Test C_HAS_WARNING-Wformat=2 - Success
-- Performing Test CXX_HAS_WARNING-Wformat=2
-- Performing Test CXX_HAS_WARNING-Wformat=2 - Success
-- Configured Fivox [788753c] with BBPSDK BBPTestData Boost Monsteer ITK Livre vmmlib libzmq
-- Configured livreDatasources [9484809] with Boost HDF5 Livre
-- Configured bbp [e41c4bc]
-- Configuring done

```