### PR TITLE
Fix in git clone for CMake/common

### DIFF
--- a/AppleCheckOpenGL.cmake
+++ b/AppleCheckOpenGL.cmake
@@ -11,10 +11,10 @@ function(apple_check_opengl Target)
 
   add_test(NAME ${Target}-AppleCheckOpenGL
     COMMAND ${CMAKE_COMMAND} -DAPPLE_CHECK_OPENGL_FILE="$<TARGET_FILE:${Target}>"
-            -P ${CMAKE_SOURCE_DIR}/CMake/common/AppleCheckOpenGL.cmake)
+            -P ${COMMON_SOURCE_DIR}/CMake/common/AppleCheckOpenGL.cmake)
   add_custom_target(${Target}-AppleCheckOpenGL
     COMMAND ${CMAKE_COMMAND} -DAPPLE_CHECK_OPENGL_FILE="$<TARGET_FILE:${Target}>"
-            -P ${CMAKE_SOURCE_DIR}/CMake/common/AppleCheckOpenGL.cmake
+            -P ${COMMON_SOURCE_DIR}/CMake/common/AppleCheckOpenGL.cmake
     COMMENT "Verifying OpenGL link libraries of ${Target}")
 
   if(NOT TARGET ${PROJECT_NAME}-tests)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # git master
 
+* The option COMMON_SOURCE_DIR now default to CMAKE_SOURCE_DIR. It present,
+  this project itself will be clone at COMMON_SOURCE_DIR for projects that
+  have updated their GitExternal file.
 * cmake 2.8.9 or later is now required
 * GitExternal.cmake:
     * 'user' remote for cloned github repositories (added if GITHUB_USER) is

--- a/CommonApplication.cmake
+++ b/CommonApplication.cmake
@@ -78,7 +78,7 @@ function(_common_gui_application Name)
     set(_BUNDLE_NAME ${Name})
     set(_COPYRIGHT ${${NAME}_COPYRIGHT})
     set(_ICON ${${NAME}_ICON})
-    configure_file(${CMAKE_SOURCE_DIR}/CMake/common/Info.plist.in
+    configure_file(${COMMON_SOURCE_DIR}/CMake/common/Info.plist.in
       ${CMAKE_CURRENT_BINARY_DIR}/Info.plist @ONLY)
 
     _common_application(${Name} MACOSX_BUNDLE ${${NAME}_ICON} ${ARGN})

--- a/CommonLibrary.cmake
+++ b/CommonLibrary.cmake
@@ -82,11 +82,11 @@ function(_common_library Name)
 
   # Generate api.h and version.h/cpp for non-interface libraries
   if(${NAME}_SOURCES)
-    configure_file(${CMAKE_SOURCE_DIR}/CMake/common/cpp/api.h
+    configure_file(${COMMON_SOURCE_DIR}/CMake/common/cpp/api.h
       ${OUTPUT_INCLUDE_DIR}/${INCLUDE_NAME}/api.h @ONLY)
-    configure_file(${CMAKE_SOURCE_DIR}/CMake/common/cpp/version.h
+    configure_file(${COMMON_SOURCE_DIR}/CMake/common/cpp/version.h
       ${OUTPUT_INCLUDE_DIR}/${INCLUDE_NAME}/version.h @ONLY)
-    configure_file(${CMAKE_SOURCE_DIR}/CMake/common/cpp/version.cpp
+    configure_file(${COMMON_SOURCE_DIR}/CMake/common/cpp/version.cpp
       ${CMAKE_CURRENT_BINARY_DIR}/version.cpp @ONLY)
 
     # ${NAMESPACE}_API= -> Fix cppcheck error about not including version.h
@@ -138,7 +138,7 @@ function(_common_library Name)
         add_library(${LibName} INTERFACE)
       else()
         add_library(${LibName} ${PUBLIC_HEADERS}
-                               ${CMAKE_SOURCE_DIR}/CMake/common/cpp/dummy.cpp)
+                               ${COMMON_SOURCE_DIR}/CMake/common/cpp/dummy.cpp)
         set_target_properties(${LibName} PROPERTIES
           LINKER_LANGUAGE CXX FOLDER ${PROJECT_NAME})
       endif()

--- a/CommonPackage.cmake
+++ b/CommonPackage.cmake
@@ -185,7 +185,7 @@ macro(common_package_post)
     set(__options_cmake_file ${CMAKE_CURRENT_BINARY_DIR}/options.cmake)
   endif()
 
-  configure_file(${CMAKE_SOURCE_DIR}/CMake/common/cpp/defines.h
+  configure_file(${COMMON_SOURCE_DIR}/CMake/common/cpp/defines.h
     ${OUTPUT_INCLUDE_DIR}/${PROJECT_INCLUDE_NAME}/defines.h @ONLY)
   set(__defines_file
     "${CMAKE_CURRENT_BINARY_DIR}/include/${PROJECT_INCLUDE_NAME}/defines${SYSTEM}.h")

--- a/GitExternal.cmake
+++ b/GitExternal.cmake
@@ -122,8 +122,7 @@ function(GIT_EXTERNAL DIR REPO tag)
     message(STATUS "git clone ${_msg_text} ${REPO} ${DIR} ${_msg_tag}")
     execute_process(
       COMMAND "${GIT_EXECUTABLE}" clone ${_clone_options} ${REPO} ${DIR}
-      RESULT_VARIABLE nok ERROR_VARIABLE error
-      WORKING_DIRECTORY "${GIT_EXTERNAL_DIR}")
+      RESULT_VARIABLE nok ERROR_VARIABLE error)
     if(nok)
       message(FATAL_ERROR "${DIR} clone failed: ${error}\n")
     endif()

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Copy [GitExternal](GitExternal.cmake) from this repository to CMake/,
 and use it in your top-level CMakeLists.txt as follows:
 
     list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake
-                                  ${CMAKE_SOURCE_DIR}/CMake/common)
+                                  ${COMMON_SOURCE_DIR}/CMake/common)
     include(GitExternal)
     include(Common)
 


### PR DESCRIPTION
GitExternal is using a potentially non-existing directory to clone it
when COMMON_SOURCE_DIR is set, however the git command doesn't need
any specific working directory to do the job.