### PR TITLE
Remove -DBOOST_TEST_DYN_LINK from all translation units

### DIFF
--- a/CommonCPPCTest.cmake
+++ b/CommonCPPCTest.cmake
@@ -48,9 +48,11 @@ list(SORT TEST_FILES)
 set(ALL_CPP_TESTS)
 set(ALL_CPP_PERF_TESTS)
 
-set(TEST_ENABLE_BOOST_HEADER "Add -DBOOST_TEST_DYN_LINK to tests" CACHE BOOL ON)
 # backwards compat: generate main() for unit tests
 #  should really #define BOOST_TEST_DYN_LINK if using boost
+if(NOT DEFINED TEST_ENABLE_BOOST_HEADER)
+  set(TEST_ENABLE_BOOST_HEADER ON)
+endif()
 if(NOT Boost_USE_STATIC_LIBS AND TEST_ENABLE_BOOST_HEADER)
   add_definitions(-DBOOST_TEST_DYN_LINK)
 endif()

--- a/CommonCPPCTest.cmake
+++ b/CommonCPPCTest.cmake
@@ -27,6 +27,7 @@
 # * UNIT_AND_PERF_TESTS a list with files which should be compiled
 #   also as performance tests. The unit test will be named 'file',
 #   whereas the performance test will be named 'perf-file'.
+# * TEST_ENABLE_BOOST_HEADER adds -DBOOST_TEST_DYN_LINK to tests
 
 include(CommonCheckTargets)
 
@@ -46,6 +47,13 @@ list(SORT TEST_FILES)
 
 set(ALL_CPP_TESTS)
 set(ALL_CPP_PERF_TESTS)
+
+set(TEST_ENABLE_BOOST_HEADER "Add -DBOOST_TEST_DYN_LINK to tests" CACHE BOOL ON)
+# backwards compat: generate main() for unit tests
+#  should really #define BOOST_TEST_DYN_LINK if using boost
+if(NOT Boost_USE_STATIC_LIBS AND TEST_ENABLE_BOOST_HEADER)
+  add_definitions(-DBOOST_TEST_DYN_LINK)
+endif()
 
 macro(common_add_cpp_test NAME FILE)
   set(TEST_NAME ${PROJECT_NAME}-${NAME})

--- a/FindBoostConfig.cmake
+++ b/FindBoostConfig.cmake
@@ -10,9 +10,6 @@ set(Boost_NO_BOOST_CMAKE ON CACHE BOOL "Enable fix for FindBoost.cmake" )
 set(Boost_DETAILED_FAILURE_MSG ON) # Output which components are missing
 add_definitions(-DBOOST_ALL_NO_LIB) # Don't use 'pragma lib' on Windows
 add_definitions(-DBoost_NO_BOOST_CMAKE) # Fix for CMake problem in FindBoost
-if(NOT Boost_USE_STATIC_LIBS)
-  add_definitions(-DBOOST_TEST_DYN_LINK) # generates main() for unit tests
-endif()
 if(NOT "$ENV{BOOST_ROOT}" STREQUAL "" OR
     NOT "$ENV{BOOST_LIBRARYDIR}" STREQUAL "")
   # Fix find of non-system Boost


### PR DESCRIPTION
* Above define was being set on all translation units,
  this is only necessary for boost tests, and should be
  defined only when required