### PR TITLE
Fix a regression in 1f21ab0.

### DIFF
--- a/CommonPackage.cmake
+++ b/CommonPackage.cmake
@@ -131,8 +131,8 @@ macro(common_package Package_Name)
 
     # for defines.h
     set(__use_package_define "${UPPER_PROJECT_NAME}_USE_${PACKAGE_NAME}")
-    string(REGEX REPLACE "-" "_" __use_package_define ${__use_package_define})
-    string(REGEX REPLACE "+" "P" __use_package_define ${__use_package_define})
+    string(REPLACE "-" "_" __use_package_define ${__use_package_define})
+    string(REPLACE "+" "P" __use_package_define ${__use_package_define})
     list(APPEND COMMON_PACKAGE_DEFINES ${__use_package_define})
 
     # for CommonPackageConfig.cmake


### PR DESCRIPTION
Do no use regex replace for package name to define translation. Using
+ in a regex without escaping is wrong.