### PR TITLE
split Compiler.cmake to separate compiler ident from setting options

### DIFF
--- a/Compiler.cmake
+++ b/Compiler.cmake
@@ -56,7 +56,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
 
   if(CMAKE_COMPILER_IS_CLANG)
     set(COMMON_C_FLAGS
-      "${COMMON_C_FLAGS} -Qunused-arguments -ferror-limit=6 -ftemplate-depth-1024 -Wheader-hygiene")
+      "${COMMON_C_FLAGS} -Qunused-arguments -ferror-limit=5 -ftemplate-depth-1024 -Wheader-hygiene")
     set(COMMON_CXX11_STDLIB "-stdlib=libc++")
   else()
     if(GCC_COMPILER_VERSION VERSION_LESS COMMON_MINIMUM_GCC_VERSION)

--- a/Compiler.cmake
+++ b/Compiler.cmake
@@ -22,11 +22,6 @@
 # * COMMON_CXX_FLAGS_DEBUG The common flags for C++ compiler in Debug build
 # * COMMON_CXX_FLAGS_RELWITHDEBINFO The common flags for C++ compiler in RelWithDebInfo build
 # * COMMON_CXX_FLAGS_RELEASE The common flags for C++ compiler in Release build
-# * C_DIALECT_OPT_C89    Compiler flag to select C89 C dialect
-# * C_DIALECT_OPT_C89EXT Compiler flag to select C89 C dialect with extensions
-# * C_DIALECT_OPT_C99    Compiler flag to select C99 C dialect
-# * C_DIALECT_OPT_C99EXT Compiler flag to select C99 C dialect with extensions
-# * COMMON_USE_CXX03 Set if the compiler does only support C++03
 
 # OPT: necessary only once, included by Common.cmake
 if(COMPILER_DONE)
@@ -34,30 +29,7 @@ if(COMPILER_DONE)
 endif()
 set(COMPILER_DONE ON)
 
-include(TestBigEndian)
-test_big_endian(BIGENDIAN)
-
-if(BIGENDIAN)
-  add_definitions(-DCOMMON_BIGENDIAN)
-else()
-  add_definitions(-DCOMMON_LITTLEENDIAN)
-endif()
-
-# Compiler name
-if(CMAKE_CXX_COMPILER_ID STREQUAL "XL")
-  set(CMAKE_COMPILER_IS_XLCXX ON)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
-  set(CMAKE_COMPILER_IS_INTEL ON)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  set(CMAKE_COMPILER_IS_CLANG ON)
-elseif(CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_COMPILER_IS_GNUCXX_PURE ON)
-endif()
-# use MSVC for Visual Studio
-
-if(NOT COMMON_MINIMUM_GCC_VERSION)
-  set(COMMON_MINIMUM_GCC_VERSION 4.4)
-endif()
+include(${CMAKE_CURRENT_LIST_DIR}/CompilerIdentification.cmake)
 
 option(ENABLE_WARN_DEPRECATED "Enable deprecation warnings" ON)
 option(ENABLE_CXX11_STDLIB "Enable C++11 stdlib" OFF)
@@ -66,22 +38,25 @@ if(ENABLE_WARN_DEPRECATED)
   add_definitions(-DWARN_DEPRECATED) # projects have to pick this one up
 endif()
 
-# GCC (+clang)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
-  include(${CMAKE_CURRENT_LIST_DIR}/CompilerVersion.cmake)
-  compiler_dumpversion(GCC_COMPILER_VERSION)
+  if(NOT COMMON_MINIMUM_GCC_VERSION)
+    set(COMMON_MINIMUM_GCC_VERSION 4.4)
+  endif()
 
   set(COMMON_C_FLAGS
     "-Wall -Wextra -Winvalid-pch -Winit-self -Wno-unknown-pragmas")
+
   if(NOT WIN32 AND NOT XCODE_VERSION)
     set(COMMON_C_FLAGS "${COMMON_C_FLAGS} -Werror")
   endif()
+
   if(GCC_COMPILER_VERSION VERSION_GREATER 4.1)
     set(COMMON_C_FLAGS "${COMMON_C_FLAGS} -Wshadow")
   endif()
+
   if(CMAKE_COMPILER_IS_CLANG)
     set(COMMON_C_FLAGS
-      "${COMMON_C_FLAGS} -Qunused-arguments -ferror-limit=5 -ftemplate-depth-1024 -Wheader-hygiene")
+      "${COMMON_C_FLAGS} -Qunused-arguments -ferror-limit=6 -ftemplate-depth-1024 -Wheader-hygiene")
     set(COMMON_CXX11_STDLIB "-stdlib=libc++")
   else()
     if(GCC_COMPILER_VERSION VERSION_LESS COMMON_MINIMUM_GCC_VERSION)
@@ -89,8 +64,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
     endif()
     if(GCC_COMPILER_VERSION VERSION_GREATER 4.5)
       set(COMMON_C_FLAGS "${COMMON_C_FLAGS} -fmax-errors=5")
-    else()
-      set(COMMON_USE_CXX03 ON)
     endif()
   endif()
 
@@ -101,27 +74,13 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
     # use C++03 std and stdlib, which is the default used by all
     # software, including all MacPorts.
   elseif(NOT COMMON_USE_CXX03)
-    if(CMAKE_COMPILER_IS_CLANG)
-      set(COMMON_CXXSTD_FLAGS "-std=c++11")
-    elseif(NOT GCC_COMPILER_VERSION VERSION_LESS 4.3)
-      if(GCC_COMPILER_VERSION VERSION_LESS 4.7)
-        set(COMMON_CXXSTD_FLAGS "-std=c++0x")
-      else()
-        if(GCC_COMPILER_VERSION VERSION_LESS 4.8)
-          # http://stackoverflow.com/questions/4438084
-          add_definitions(-D_GLIBCXX_USE_NANOSLEEP)
-        endif()
-        set(COMMON_CXXSTD_FLAGS "-std=c++11")
-      endif()
+    set(COMMON_CXXSTD_FLAGS ${CXX_DIALECT_11})
+    if(CMAKE_COMPILER_IS_GNUCXX_PURE AND GCC_COMPILER_VERSION VERSION_LESS 4.8)
+      # http://stackoverflow.com/questions/4438084
+      add_definitions(-D_GLIBCXX_USE_NANOSLEEP)
     endif()
   endif()
 
-  set(C_DIALECT_OPT_C89    "-std=c89")
-  set(C_DIALECT_OPT_C89EXT "-std=gnu89")
-  set(C_DIALECT_OPT_C99    "-std=c99")
-  set(C_DIALECT_OPT_C99EXT "-std=gnu99")
-
-# icc
 elseif(CMAKE_COMPILER_IS_INTEL)
   set(COMMON_C_FLAGS
     "-Wall -Wextra -Winvalid-pch -Winit-self -Wno-unknown-pragmas")
@@ -132,16 +91,11 @@ elseif(CMAKE_COMPILER_IS_INTEL)
   # supported compilation host
   set(COMMON_C_FLAGS_RELEASE "${COMMON_C_FLAGS_RELEASE} -xhost")
   set(COMMON_CXX_FLAGS_RELEASE "${COMMON_CXX_FLAGS_RELEASE} -xhost")
+
   if(NOT COMMON_USE_CXX03)
-    set(COMMON_CXXSTD_FLAGS "-std=c++11")
+    set(COMMON_CXXSTD_FLAGS ${CXX_DIALECT_11})
   endif()
 
-  set(C_DIALECT_OPT_C89    "-std=c89")
-  set(C_DIALECT_OPT_C89EXT "-std=gnu89")
-  set(C_DIALECT_OPT_C99    "-std=c99")
-  set(C_DIALECT_OPT_C99EXT "-std=gnu99")
-
-# xlc/BlueGene/PPC
 elseif(CMAKE_COMPILER_IS_XLCXX)
   # default: Maintain code semantics Fix to link dynamically. On the
   # next pass should add an if statement: 'if shared ...'.  Overriding
@@ -163,14 +117,8 @@ elseif(CMAKE_COMPILER_IS_XLCXX)
   set(CMAKE_C_FLAGS_RELEASE ${COMMON_C_FLAGS_RELEASE})
   set(CMAKE_CXX_FLAGS_RELEASE ${COMMON_CXX_FLAGS_RELEASE})
 
-  set(C_DIALECT_OPT_C89    "-qlanglvl=stdc89")
-  set(C_DIALECT_OPT_C89EXT "-qlanglvl=extc89")
-  set(C_DIALECT_OPT_C99    "-qlanglvl=stdc99")
-  set(C_DIALECT_OPT_C99EXT "-qlanglvl=extc99")
-  set(COMMON_USE_CXX03 ON)
 endif()
 
-# Visual Studio
 if(MSVC)
   add_definitions(
     /D_CRT_SECURE_NO_WARNINGS
@@ -212,4 +160,3 @@ macro(common_compiler_flags)
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${COMMON_CXX_FLAGS_RELWITHDEBINFO} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
   set(CMAKE_CXX_FLAGS_RELEASE "${COMMON_CXX_FLAGS_RELEASE} ${CMAKE_CXX_FLAGS_RELEASE}")
 endmacro()
-

--- a/CompilerIdentification.cmake
+++ b/CompilerIdentification.cmake
@@ -1,0 +1,79 @@
+# Detects the compiler, and sets the following:
+# CMAKE_COMPILER_IS_XLCXX for IBM XLC
+# CMAKE_COMPILER_IS_INTEL for Intel C++ Compiler
+# CMAKE_COMPILER_IS_CLANG for clang
+# CMAKE_COMPILER_IS_GNUCXX_PURE for *real* gcc
+#
+# Also sets the following, so that the correct C dialect flags can be used
+# * C_DIALECT_OPT_C89    Compiler flag to select C89 C dialect
+# * C_DIALECT_OPT_C89EXT Compiler flag to select C89 C dialect with extensions
+# * C_DIALECT_OPT_C99    Compiler flag to select C99 C dialect
+# * C_DIALECT_OPT_C99EXT Compiler flag to select C99 C dialect with extensions
+#
+# COMMON_USE_CXX03 Set if the compiler only supports C++03
+#
+# C++ dialect options are setup as follows:
+# * CXX_DIALECT_PRE_11  Pre-C++11, note: this could be C++98 or C++03, largely
+#                       because g++ aliases the two, and the other compilers
+#                       don't allow one to distinguish
+# * CXX_DIALECT_11      C++11 standard
+
+include(TestBigEndian)
+test_big_endian(BIGENDIAN)
+
+if(BIGENDIAN)
+  add_definitions(-DCOMMON_BIGENDIAN)
+else()
+  add_definitions(-DCOMMON_LITTLEENDIAN)
+endif()
+
+# Compiler name
+if(CMAKE_CXX_COMPILER_ID STREQUAL "XL")
+  set(CMAKE_COMPILER_IS_XLCXX ON)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+  set(CMAKE_COMPILER_IS_INTEL ON)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  set(CMAKE_COMPILER_IS_CLANG ON)
+elseif(CMAKE_COMPILER_IS_GNUCXX)
+  set(CMAKE_COMPILER_IS_GNUCXX_PURE ON)
+endif()
+# use MSVC for Visual Studio
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
+  include(${CMAKE_CURRENT_LIST_DIR}/CompilerVersion.cmake)
+  compiler_dumpversion(GCC_COMPILER_VERSION)
+
+  set(CXX_DIALECT_PRE_11 "-std=c++98")
+
+  set(CXX_DIALECT_11 "-std=c++11")
+  if(GCC_COMPILER_VERSION VERSION_LESS 4.7)
+    set(CXX_DIALECT_11 "-std=c++0x")
+  endif()
+
+  if(CMAKE_COMPILER_IS_GNUCXX_PURE AND GCC_COMPILER_VERSION VERSION_LESS 4.5)
+    set(COMMON_USE_CXX03 ON)
+  endif()
+
+  set(C_DIALECT_OPT_C89 "-std=c89")
+  set(C_DIALECT_OPT_C99 "-std=c99")
+  set(C_DIALECT_OPT_C89EXT "-std=gnu89")
+  set(C_DIALECT_OPT_C99EXT "-std=gnu99")
+
+elseif(CMAKE_COMPILER_IS_INTEL)
+  set(CXX_DIALECT_11 "-std=c++11")
+  set(CXX_DIALECT_PRE_11 "-std=gnu++98")
+
+  set(C_DIALECT_OPT_C89 "-std=c89")
+  set(C_DIALECT_OPT_C99 "-std=c99")
+  set(C_DIALECT_OPT_C89EXT "-std=gnu89")
+  set(C_DIALECT_OPT_C99EXT "-std=gnu99")
+
+elseif(CMAKE_COMPILER_IS_XLCXX)
+  set(COMMON_USE_CXX03 ON)
+  set(CXX_DIALECT_PRE_11 "")
+
+  set(C_DIALECT_OPT_C89 "-qlanglvl=stdc89")
+  set(C_DIALECT_OPT_C99 "-qlanglvl=stdc99")
+  set(C_DIALECT_OPT_C89EXT "-qlanglvl=extc89")
+  set(C_DIALECT_OPT_C99EXT "-qlanglvl=extc99")
+endif()

--- a/CompilerIdentification.cmake
+++ b/CompilerIdentification.cmake
@@ -69,8 +69,10 @@ elseif(CMAKE_COMPILER_IS_INTEL)
   set(C_DIALECT_OPT_C99EXT "-std=gnu99")
 
 elseif(CMAKE_COMPILER_IS_XLCXX)
+  #read up on the features with 'xlc++ -qhelp'
   set(COMMON_USE_CXX03 ON)
-  set(CXX_DIALECT_PRE_11 "")
+  set(CXX_DIALECT_PRE_11 "-qlanglvl=extended") #strict98, with some ... extra features
+  set(CXX_DIALECT_11 "-qlanglvl=extended0x")
 
   set(C_DIALECT_OPT_C89 "-qlanglvl=stdc89")
   set(C_DIALECT_OPT_C99 "-qlanglvl=stdc99")


### PR DESCRIPTION
* new file: CompilerIdentification.cmake, takes care of setting
   - compiler names (CMAKE_COMPILER_IS_...), and the C and C++ dialect
     options: (C_DIALECT_OPT_..., CXX_DIALECT_...) which cleans up the
     logic in the Compiler.cmake to mainly deal with flags

Note: with g++, I used std=c++03 is an alias to c++98, in the
different versions of source I've looked at, hence the term
'CXX_DIALECT_PRE_11' is used to signify both.

Investigation:
```
GCC:
   #Default RH6.7
   $ g++ -dumpversion
   4.4.7
   $ echo | g++ -std=c++03 -x c++ -E -
   cc1plus: error: unrecognized command line option "-std=c++03"
   $ echo | g++ -std=c++98 -x c++ -E -

   #default Ubuntu LTS12.04
   $ g++ -dumpversion
   4.6
   $ echo | g++ -std=c++03 -x c++ -E -
   $ echo | g++ -std=c++98 -x c++ -E -
   # Note: I think this is -std=c++03 is an alias for -std=c++98
   #https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/c-family/c.opt;h=4c4727f31c5719b6fbf2db0b1e9fdb497b86b142;hb=31839765ee7d53766a69f418e9d7a4ed750de4e9#l1143
   #Thanks to Juan for mentioning something like this may exist

   # from BBP/viz/env/2015.10.22
   $ g++ -dumpversion
   4.8.3
   $ echo | g++ -std=c++03 -x c++ -E -
   gevaert@bbpviz1 ~/private/src/CMake (master)$ echo | g++ -std=c++98 -x c++ -E -
   #alias for c++98:
   #https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/c-family/c.opt;h=4da80b0edf558d2ab7b2ce740d0fca4fc4901929;hb=6bbf0dec66c0e719b06cd2fe67559fda6df09000#l1367

ICC:
   # from module load intel/icomposer-2015.0.090
   icpc -help
      snip>>
      -std=<std>
      c++11 enable C++11 experimental support for C++ programs
      c++0x same as c++11
      gnu++98 conforms to 1998 ISO C++ standard plus GNU extensions
      gnu++11 conforms to 2011 ISO C++ standard plus GNU extensions
      gnu++0x same as gnu++11
      snip>>
```