### PR TITLE
Do not mess with LCOV_EXCLUDE which is set by outside users

### DIFF
--- a/CommonCPPCTest.cmake
+++ b/CommonCPPCTest.cmake
@@ -167,8 +167,5 @@ add_dependencies(tests ${PROJECT_NAME}-tests)
 add_dependencies(${PROJECT_NAME}-nightlytests ${PROJECT_NAME}-perftests)
 
 if(COMMON_ENABLE_COVERAGE)
-  foreach(TEST_FILE ${TEST_FILES})
-    list(APPEND LCOV_EXCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/${TEST_FILE}")
-  endforeach()
   add_coverage_targets(${PROJECT_NAME}-cpptests)
 endif()


### PR DESCRIPTION
After #486, excluding the tests is not needed anymore.