### PR TITLE
Make Version::getRevision great again!

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # git master
 
-# 2016.12(09-Dec-2016)
+* [530](https://github.com/Eyescale/CMake/pull/530):
+  Fix return value of Version::getRevision to 64 bit for longer git SHAs
+
+# 2016.12 (09-Dec-2016)
 
 * [529](https://github.com/Eyescale/CMake/pull/529):
   Fix python3 finding on OSX with -DUSE_PYTHON_VERSION=3

--- a/cpp/version.cpp
+++ b/cpp/version.cpp
@@ -33,7 +33,7 @@ std::string Version::getString()
     return version.str();
 }
 
-int Version::getRevision()
+unsigned long long Version::getRevision()
 {
     return @NAMESPACE@_VERSION_REVISION;
 }

--- a/cpp/version.h
+++ b/cpp/version.h
@@ -26,7 +26,7 @@ namespace @namespace@
 #   define @NAMESPACE@_VERSION_REVISION 0x@GIT_REVISION@
 
     /** The current binary interface. */
-#   define @NAMESPACE@_VERSION_ABI @PROJECT_VERSION_ABI@
+#   define @NAMESPACE@_VERSION_ABI @PROJECT_VERSION_ABI@ull
 
 /** True if the current version is newer than the given one. */
 #   define @NAMESPACE@_VERSION_GT( MAJOR, MINOR, PATCH )       \
@@ -69,7 +69,7 @@ public:
     static std::string getString();
 
     /** @return the SCM revision. */
-    static int getRevision();
+    static unsigned long long getRevision();
 
     /** @return the current binary interface version of @Name@. */
     static int getABI();


### PR DESCRIPTION
git recently introduced a change that short commit SHAs get longer to
avoid collisions. This bit Equalizer now, where git-describe delivers 9
byte of SHA.