### PR TITLE
Extracted common_help() out of common_application()

### DIFF
--- a/CommonApplication.cmake
+++ b/CommonApplication.cmake
@@ -20,13 +20,11 @@
 # * NAME_ICON optional .icns file (Mac OS GUI applications only)
 # * NAME_COPYRIGHT optional copyright notice (Mac OS GUI applications only)
 #
-# Output Global Properties
-# * ${PROJECT_NAME}_HELP help page names generated (see DoxygenRule.cmake)
-#
-# Builds Name application and installs it.
+# Builds Name application, generates doxygen help page and installs it.
 
 include(AppleCheckOpenGL)
 include(CommonCheckTargets)
+include(CommonHelp)
 include(CMakeParseArguments)
 include(StringifyShaders)
 
@@ -127,38 +125,7 @@ function(common_application Name)
   endif()
 
   if(NOT THIS_NOHELP)
-    # run binary with --help to capture output for doxygen
-    set(_doc "${PROJECT_BINARY_DIR}/help/${Name}.md")
-    set(_cmake "${CMAKE_CURRENT_BINARY_DIR}/${Name}.cmake")
-    file(WRITE ${_cmake} "
-      execute_process(COMMAND \${APP} --help
-      OUTPUT_FILE ${_doc} ERROR_FILE ${_doc}.error)
-      file(READ ${_doc} _doc_content)
-      if(NOT _doc_content)
-        message(FATAL_ERROR \"${Name} is missing --help\")
-      endif()
-      file(WRITE ${_doc} \"${Name} {#${Name}}
-============
-
-```
-\${_doc_content}
-```
-\")
-")
-    add_custom_command(OUTPUT ${_doc}
-      COMMAND ${CMAKE_COMMAND} -DAPP=$<TARGET_FILE:${Name}> -P ${_cmake}
-      DEPENDS ${Name} COMMENT "Creating help for ${Name}")
-    add_custom_target(${Name}-help DEPENDS ${_doc})
-    set_target_properties(${Name}-help PROPERTIES
-      EXCLUDE_FROM_DEFAULT_BUILD ON FOLDER ${PROJECT_NAME}/doxygen)
-    set_property(GLOBAL APPEND PROPERTY ${PROJECT_NAME}_HELP ${Name})
-
-    if(NOT TARGET ${PROJECT_NAME}-help)
-      add_custom_target(${PROJECT_NAME}-help)
-      set_target_properties(${PROJECT_NAME}-help PROPERTIES
-        EXCLUDE_FROM_DEFAULT_BUILD ON FOLDER ${PROJECT_NAME}/doxygen)
-    endif()
-    add_dependencies(${PROJECT_NAME}-help ${Name}-help)
+    common_help(${Name})
   endif()
 
   if(NOT ${NAME}_OMIT_CHECK_TARGETS)

--- a/CommonHelp.cmake
+++ b/CommonHelp.cmake
@@ -1,0 +1,77 @@
+# Copyright (c) 2017 Stefan.Eilemann@epfl.ch
+#                    Raphael.Dumusc@epfl.ch
+#
+# Generate help page for doxygen by running Name application with --help:
+#   common_help(<Name> [LOCATION location])
+#
+# Arguments:
+# * Name: an existing application target
+# * LOCATION: (Optional) location of the application for custom targets such as
+#   python scripts. For EXECUTABLE targets $<TARGET_FILE:${Name}> is used by
+#   default.
+#
+# Output Global Properties:
+# * ${PROJECT_NAME}_HELP help page names generated (see DoxygenRule.cmake)
+#
+# Targets generated:
+# * ${Name}-help to generate the help file for a given application
+# * ${PROJECT_NAME}-help to generate the help for the current project
+
+include(CMakeParseArguments)
+include(CommonTarget)
+
+function(common_help Name)
+  set(_opts)
+  set(_singleArgs LOCATION)
+  set(_multiArgs)
+  cmake_parse_arguments(THIS "${_opts}" "${_singleArgs}" "${_multiArgs}"
+    ${ARGN})
+
+  # run binary with --help to capture output for doxygen
+  set(_doc "${PROJECT_BINARY_DIR}/help/${Name}.md")
+  set(_cmake "${CMAKE_CURRENT_BINARY_DIR}/${Name}.cmake")
+  file(WRITE ${_cmake} "
+    execute_process(COMMAND \${APP} --help TIMEOUT 5 RESULT_VARIABLE _result
+      OUTPUT_VARIABLE _help_content OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_VARIABLE _error  ERROR_STRIP_TRAILING_WHITESPACE
+    )
+    if(NOT _result EQUAL 0 OR NOT _help_content)
+      message(FATAL_ERROR \"${Name} is missing --help\n\${_error}\")
+    endif()
+    file(WRITE ${_doc} \"${Name} {#${Name}}
+============
+
+```
+\${_help_content}
+```
+\")
+")
+
+  if(THIS_LOCATION)
+    set(_app ${THIS_LOCATION})
+  else()
+    get_property(_type TARGET ${Name} PROPERTY TYPE)
+    if(_type STREQUAL "EXECUTABLE")
+      set(_app $<TARGET_FILE:${Name}>)
+    else()
+      message(FATAL_ERROR "common_help(${Name}): application location not "
+                          "provided for custom target")
+    endif()
+  endif()
+
+  add_custom_command(OUTPUT ${_doc}
+    COMMAND ${CMAKE_COMMAND} -DAPP=${_app} -P ${_cmake}
+    DEPENDS ${Name} COMMENT "Creating help for ${Name}")
+  add_custom_target(${Name}-help DEPENDS ${_doc})
+  set_target_properties(${Name}-help PROPERTIES
+    EXCLUDE_FROM_DEFAULT_BUILD ON FOLDER ${PROJECT_NAME}/doxygen)
+
+  set_property(GLOBAL APPEND PROPERTY ${PROJECT_NAME}_HELP ${Name})
+
+  if(NOT TARGET ${PROJECT_NAME}-help)
+    add_custom_target(${PROJECT_NAME}-help)
+    set_target_properties(${PROJECT_NAME}-help PROPERTIES
+      EXCLUDE_FROM_DEFAULT_BUILD ON FOLDER ${PROJECT_NAME}/doxygen)
+  endif()
+  add_dependencies(${PROJECT_NAME}-help ${Name}-help)
+endfunction()

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The following CMake modules can be included in your project:
       default warnings can be set on given target to common_compile_options();
       automatically applied for targets created with common_application() and
       common_library()
+    * [CommonHelp](CommonHelp.cmake) *common_help* function to create a
+      documentation page from an application's --help output.
     * [GitInfo](GitInfo.cmake) sets variables with information about the git
       source tree.
     * [GitTargets](GitTargets.cmake) *branch*, *cut*, *tag*, *erase*, *retag*,


### PR DESCRIPTION
This allows the generation of help pages for applications not compiled with common_application, such as python scripts (tide, rtneuron-app.py).