### PR TITLE
Automatically add a pre-commit hook to git repos for running clang-fo…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # git master
 
+* [537](https://github.com/Eyescale/CMake/pull/537):
+  Automatically add a pre-commit hook to git repos for running clang-format.
 * [533](https://github.com/Eyescale/CMake/pull/533):
   Add application-help-to-doxygen extraction
 * [532](https://github.com/Eyescale/CMake/pull/532):

--- a/Common.cmake
+++ b/Common.cmake
@@ -146,6 +146,7 @@ include(CommonCompiler)
 include(CommonCoverage)
 include(GitInfo)
 include(GitTargets)
+include(GitHooks)
 include(ProjectInfo)
 include(UpdateGitExternal)
 

--- a/GitHooks.cmake
+++ b/GitHooks.cmake
@@ -1,0 +1,23 @@
+# Copyright (c) 2017, Juan Hernando <juan.hernando@epfl.ch>
+#
+
+if(NOT GIT_FOUND)
+  find_package(Git QUIET)
+endif()
+
+if(NOT CLANG_FORMAT)
+  find_program(CLANG_FORMAT clang-format)
+endif()
+
+# Installing clang-format precommit hook if prerequisites are met and it doesn't
+# exist yet.
+if(GIT_FOUND AND CLANG_FORMAT AND EXISTS ${PROJECT_SOURCE_DIR}/.git AND
+   NOT EXISTS ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
+
+   # We cannot write the file from here because we need exec permissions
+   configure_file(${CMAKE_SOURCE_DIR}/CMake/common/util/git_pre-commit.in
+                  ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
+endif()
+
+
+

--- a/util/git_pre-commit.in
+++ b/util/git_pre-commit.in
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Copyright (c) 2017, Juan Hernando <juan.hernando@epfl.ch>
+
+GIT=${GIT_EXECUTABLE}
+CLANG_FORMAT=${CLANG_FORMAT}
+
+# Checking if this project has a .clang-format style file at the root dir.
+if ! [[ -e $PWD/.clang-format ]]; then
+    exit 0
+fi
+
+files=$($GIT diff --cached --name-only --diff-filter=ACM)
+
+for file in $files; do
+    for ext in c cpp h hpp ipp frag vert glsl ispc ih; do
+        if [[ "$file" == *.$ext ]]; then
+            # We run clang-format only in files that are fully staged and warn
+            # about the others
+            if [[ $($GIT diff --name-only "$file") == "$file" ]]; then
+                echo "clang-format not run on partially added file $file"
+            else
+                $CLANG_FORMAT -i -style=file $PWD/$file
+                $GIT add $file
+            fi
+            break;
+        fi
+    done
+done


### PR DESCRIPTION
…rmat.

The pre-commit hook is a bash script using only built-ins, git and
clang_format. The hook is not added if the project being configured already
has one.
The script does nothing if a .clang-format is not found and it only processes
files that are added enterily to the index.