### PR TITLE
Making CMake/common usable as a .gitmodule in subprojects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # git master
 
+* [551](https://github.com/Eyescale/CMake/pull/551):
+  Subproject changes:
+    * Cloning of subprojects has been disabled by default. Users must explicitly
+      set -DCLONE_SUBPROJECTS=ON to clone missing dependencies during the cmake
+      run.
+    * CMake/common can be integrated as a .gitmodule without getting an
+      unnecessary copy in each subproject.
 * [540](https://github.com/Eyescale/CMake/pull/540):
   Add CommonSmokeTest.cmake to check execution of installed applications
 * [537](https://github.com/Eyescale/CMake/pull/537):

--- a/GitExternal.cmake
+++ b/GitExternal.cmake
@@ -113,7 +113,12 @@ function(GIT_EXTERNAL DIR REPO tag)
     if(nok)
       message(FATAL_ERROR "git checkout ${TAG} in ${DIR} failed: ${error}\n")
     else()
-      execute_process(COMMAND "${GIT_EXECUTABLE}" submodule update --init --recursive
+      # init submodules of the subproject, excluding CMake/common if present
+      execute_process(COMMAND "${GIT_EXECUTABLE}" submodule init
+        WORKING_DIRECTORY "${DIR}" OUTPUT_QUIET)
+      execute_process(COMMAND "${GIT_EXECUTABLE}" submodule deinit CMake/common
+        WORKING_DIRECTORY "${DIR}" OUTPUT_QUIET ERROR_QUIET)
+      execute_process(COMMAND "${GIT_EXECUTABLE}" submodule update --recursive
         WORKING_DIRECTORY "${DIR}")
     endif()
   endif()

--- a/README.md
+++ b/README.md
@@ -1,8 +1,22 @@
 # CMake Modules
 
 This repository contains common CMake modules and a collection of find scripts
-to locate non-CMake dependencies. To use it, create a .gitexternals file in your
-project with the content:
+to locate non-CMake dependencies. The recommended way to use it is:
+
+## As a git submodule
+
+In your project source dir, do:
+
+    git submodule add https://github.com/Eyescale/CMake CMake/common
+
+And include it in the top-level CMakeLists.txt as follows:
+
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMake/common)
+    include(Common)
+
+## As a git externals (deprecated)
+
+Create a .gitexternals file in your project with the content:
 
     # -*- mode: cmake -*-
     # CMake/common https://github.com/Eyescale/CMake.git master

--- a/SubProject.cmake
+++ b/SubProject.cmake
@@ -33,6 +33,7 @@
 # then it can check the variable ${PROJECT_NAME}_IS_SUBPROJECT.
 #
 # SubProject.cmake respects the following variables:
+# - CLONE_SUBPROJECTS: when set, subprojects are git-cloned if missing.
 # - DISABLE_SUBPROJECTS: when set, does not load sub projects. Useful for
 #   example for continuous integration builds
 # - SUBPROJECT_${name}: If set to OFF, the subproject is not added.
@@ -81,7 +82,9 @@ function(add_subproject name)
 
   if(NOT EXISTS "${path}/")
     message(FATAL_ERROR
-      "Subproject ${name} not found in ${path}")
+      "Subproject ${name} not found in ${path}, do:\n"
+      "cmake -DCLONE_SUBPROJECTS=ON\n"
+      "to git-clone it automatically.")
   endif()
   # enter again to catch direct add_subproject() calls
   common_graph_dep(${PROJECT_NAME} ${name} TRUE TRUE)
@@ -135,7 +138,9 @@ macro(git_subproject name url tag)
         if((NOT ${NAME}_FOUND AND NOT ${name}_FOUND) OR
             ${NAME}_FOUND_SUBPROJECT)
           # not found externally, add as sub project
-          git_external(${__common_source_dir}/${name} ${url} ${tag})
+          if(CLONE_SUBPROJECTS)
+            git_external(${__common_source_dir}/${name} ${url} ${tag})
+          endif()
           add_subproject(${name})
         endif()
       endif()


### PR DESCRIPTION
The new CLONE_SUBPROJECTS option offers extra granularity between building with subprojects and clone operations. This is what we discussed today but I am not sure if such fine-grained control is needed. We could also simply replace DISABLE_SUBPROJECTS with a single SUBPROJECTS=ON switch. Both solutions would satisfy the criteria of no clone operations during the configure step by default.