### PR TITLE
Fix finding libjpeg-turbo-devel .rpm package with jconfig-64.h

### DIFF
--- a/FindLibJpegTurbo.cmake
+++ b/FindLibJpegTurbo.cmake
@@ -21,7 +21,9 @@ find_path(LibJpegTurbo_INCLUDE_DIR
 
 # Search for header with version: jconfig.h
 if(LibJpegTurbo_INCLUDE_DIR)
-  if(EXISTS "${LibJpegTurbo_INCLUDE_DIR}/jconfig.h")
+  if(EXISTS "${LibJpegTurbo_INCLUDE_DIR}/jconfig-64.h")
+    set(_version_header "${LibJpegTurbo_INCLUDE_DIR}/jconfig-64.h")
+  elseif(EXISTS "${LibJpegTurbo_INCLUDE_DIR}/jconfig.h")
     set(_version_header "${LibJpegTurbo_INCLUDE_DIR}/jconfig.h")
   elseif(EXISTS "${LibJpegTurbo_INCLUDE_DIR}/x86_64-linux-gnu/jconfig.h")
     set(_version_header "${LibJpegTurbo_INCLUDE_DIR}/x86_64-linux-gnu/jconfig.h")


### PR DESCRIPTION
Found for libjpeg-turbo 1.5.1 on Fedora 26, likely applies to other RHEL variants too.