### PR TITLE
Adapt Boost.Python finder for latest naming scheme in brew.

### DIFF
--- a/ChoosePython.cmake
+++ b/ChoosePython.cmake
@@ -53,7 +53,7 @@ if(${USE_PYTHON_VERSION} STREQUAL auto)
   # Finding Boost first if needed because if the Python3 interpreter is found
   # first there's no way back.
   if(NOT CHOOSE_PYTHON_IGNORE_BOOST)
-    foreach(__suffix 3  -py39 -py38 -py37 -py36 -py35 -py34 -py34 -py33 -py32)
+    foreach(__suffix 3 38 -py38 37 -py37 -py36 -py35 -py34 )
       find_package(Boost COMPONENTS python${__suffix} QUIET)
       if(Boost_FOUND)
         string(TOUPPER  ${__suffix} __boost_python_library_suffix)


### PR DESCRIPTION
Removed old Python versions and future 3.9