### PR TITLE
Build dependencies: replace clang-format-3.5 by clang-format

### DIFF
--- a/InstallDependencies.cmake
+++ b/InstallDependencies.cmake
@@ -60,7 +60,7 @@ function(install_dependencies name)
   # add common build requirements
   if(__pkg_type STREQUAL DEB)
     set(_dependencies cmake ccache doxygen git git-review graphviz
-      ninja-build pkg-config lcov cppcheck clang clang-format-3.5)
+      ninja-build pkg-config lcov cppcheck clang clang-format)
   elseif(APPLE)
     set(_dependencies cppcheck)
   else()


### PR DESCRIPTION
The clang-format-3.5 package is no longer available on Ubuntu 18.04, causing -DINSTALL_PACKAGES=ON to fail.

Current versions at the time of writing are:
- 16.04: clang-format-3.8
- 18.04: clang-format-6.0