### PR TITLE
Add python36 to Boost.Python finder

### DIFF
--- a/ChoosePython.cmake
+++ b/ChoosePython.cmake
@@ -53,7 +53,7 @@ if(${USE_PYTHON_VERSION} STREQUAL auto)
   # Finding Boost first if needed because if the Python3 interpreter is found
   # first there's no way back.
   if(NOT CHOOSE_PYTHON_IGNORE_BOOST)
-    foreach(__suffix 3 38 -py38 37 -py37 -py36 -py35 -py34 )
+    foreach(__suffix 3 38 -py38 37 -py37 36 -py36 -py35 -py34 )
       find_package(Boost COMPONENTS python${__suffix} QUIET)
       if(Boost_FOUND)
         string(TOUPPER  ${__suffix} __boost_python_library_suffix)


### PR DESCRIPTION
For python 3.8 and 3.7 the suffix 38 and 37 was added in the past, however for python 3.6 there is not '36' string.