### PR TITLE
Install git pre-commit hook only if there's a directory to put it in

### DIFF
--- a/GitHooks.cmake
+++ b/GitHooks.cmake
@@ -11,7 +11,7 @@ endif()
 
 # Installing clang-format precommit hook if prerequisites are met and it doesn't
 # exist yet.
-if(GIT_FOUND AND CLANG_FORMAT AND EXISTS ${PROJECT_SOURCE_DIR}/.git AND
+if(GIT_FOUND AND CLANG_FORMAT AND EXISTS ${PROJECT_SOURCE_DIR}/.git/hooks/ AND
    NOT EXISTS ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
 
    # We cannot write the file from here because we need exec permissions


### PR DESCRIPTION
The assumption that we can put a file into `.git/hooks/` if `.git` exists is wrong, e.g. if `.git` is a file (as is the case when using `git submodule`).

This PR fixes the issue by checking if `.git/hooks/` exists instead:
- the trailing slash checks for directories (or: directory-likes) rather than for mere existence (regardless of type)
- since we want to put the target file into the `hooks/` subdirectory we just check for that (just in case the `.git` directory is weird)

Closes: https://github.com/Eyescale/CMake/issues/603